### PR TITLE
Updated dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /vendor/
+composer.lock

--- a/composer.json
+++ b/composer.json
@@ -11,10 +11,9 @@
     "minimum-stability": "dev",
     "require": {
         "php": ">=5.3.0",
-        "friendsofsymfony/rest-bundle": "1.2.*@dev",
-        "jms/serializer-bundle": "0.12.*@dev",
-        "nelmio/cors-bundle": "1.2.*@dev",
-        "symfony/serializer": "2.4.*"
+        "friendsofsymfony/rest-bundle": "1.4.*",
+        "jms/serializer-bundle": "0.13.*",
+        "nelmio/cors-bundle": "1.3.*"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
This updates dependencies not to be dev ones. Closes #2 
The bundle is still in a "dev" function however.

I removed the symfony2 serializer, because it is either the SF2 one, either the JMSSerializer one IMO.

By the way, wouldn't it be better to set the libraries as suggestions more than requirements?

Thanks for your time.
