### PR TITLE
Fixing put action for proper PUT method handling.

### DIFF
--- a/src/Voryx/RESTGeneratorBundle/Resources/skeleton/rest/actions/put.php.twig
+++ b/src/Voryx/RESTGeneratorBundle/Resources/skeleton/rest/actions/put.php.twig
@@ -20,7 +20,6 @@
 {% block method_body %}
         try {
             $em = $this->getDoctrine()->getManager();
-            $request->setMethod('PATCH'); //Treat all PUTs as PATCH
             $form = $this->createForm(new {{ entity }}Type(), $entity, array("method" => $request->getMethod()));
             $this->removeExtraFields($request, $form);
             $form->handleRequest($request);


### PR DESCRIPTION
According to https://github.com/FriendsOfSymfony/FOSRestBundle/blob/master/Resources/doc/5-automatic-route-generation_single-restful-controller.md

PUT - this action accepts PUT requests to the url /resources/{id} and updates a single resource for this type
PATCH - This action also accepts PATCH requests to the url /resources/{id} and is supposed to partially modify the resource or made custom updates.

So PUT is intended to update all fields of the entity at once, while PATCH could be used for updating subset of all fields. 

Consider following scenario: we have a form with 3 fields - name, email, phone. All fields are required. If field is empty JS-frameworks often do not send it. User fill only first 2 fields (name, email) by mistake and send a PUT request to out REST API. We expect form validation to fail (since user omitted phone field). But if generated code switch request method from PUT to PATCH - request is passed but with undesired result - we now have name and email updated in our entity. Symphony code for handling form request ($form->handleRequest) detects PATCH method. For non-PATCH methods missing fields are cleared, for PATCH - they are filled with values from database-entity.

Commit where this functionality was added https://github.com/symfony/symfony/pull/7849/files

If you want, we could implement parameter for controlling this behavior (either switching PUT to PATCH or not).
