### PR TITLE
Adapted generator for symfony 2.5

### DIFF
--- a/src/Voryx/RESTGeneratorBundle/Command/GenerateDoctrineCommand.php
+++ b/src/Voryx/RESTGeneratorBundle/Command/GenerateDoctrineCommand.php
@@ -11,7 +11,7 @@
 
 namespace Voryx\RESTGeneratorBundle\Command;
 
-use Doctrine\Bundle\DoctrineBundle\Mapping\MetadataFactory;
+use Doctrine\Bundle\DoctrineBundle\Mapping\DisconnectedMetadataFactory;
 
 abstract class GenerateDoctrineCommand extends GeneratorCommand
 {
@@ -33,7 +33,7 @@ abstract class GenerateDoctrineCommand extends GeneratorCommand
 
     protected function getEntityMetadata($entity)
     {
-        $factory = new MetadataFactory($this->getContainer()->get('doctrine'));
+        $factory = new DisconnectedMetadataFactory($this->getContainer()->get('doctrine'));
 
         return $factory->getClassMetadata($entity)->getMetadata();
     }

--- a/src/Voryx/RESTGeneratorBundle/Command/GenerateDoctrineRESTCommand.php
+++ b/src/Voryx/RESTGeneratorBundle/Command/GenerateDoctrineRESTCommand.php
@@ -10,6 +10,8 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\Output;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+use Symfony\Component\Console\Question\Question;
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 use Sensio\Bundle\GeneratorBundle\Command\Helper\DialogHelper;
 use Voryx\RESTGeneratorBundle\Generator\DoctrineRESTGenerator;
@@ -70,7 +72,7 @@ EOT
         $dialog = $this->getDialogHelper();
 
         if ($input->isInteractive()) {
-            if (!$dialog->askConfirmation($output, $dialog->getQuestion('Do you confirm generation', 'yes', '?'), true)) {
+            if (!$dialog->ask($input, $output, new ConfirmationQuestion('Do you confirm generation', 'yes', '?'), true)) {
                 $output->writeln('<error>Command aborted</error>');
 
                 return 1;
@@ -127,7 +129,7 @@ EOT
             '',
         ));
 
-        $entity = $dialog->askAndValidate($output, $dialog->getQuestion('The Entity shortcut name', $input->getOption('entity')), array('Sensio\Bundle\GeneratorBundle\Command\Validators', 'validateEntityName'), false, $input->getOption('entity'));
+        $entity = $dialog->ask($input, $output, new Question('The Entity shortcut name: ', $input->getOption('entity')), array('Sensio\Bundle\GeneratorBundle\Command\Validators', 'validateEntityName'), false, $input->getOption('entity'));
         $input->setOption('entity', $entity);
         list($bundle, $entity) = $this->parseShortcutNotation($entity);
 
@@ -139,7 +141,7 @@ EOT
             'prefix: /prefix/, /prefix/new, ...).',
             '',
         ));
-        $prefix = $dialog->ask($output, $dialog->getQuestion('Routes prefix', '/'.$prefix), '/'.$prefix);
+        $prefix = $dialog->ask($input, $output, new Question('Routes prefix: ', '/'.$prefix), '/'.$prefix);
         $input->setOption('route-prefix', $prefix);
 
         // summary
@@ -168,7 +170,7 @@ EOT
     {
         $auto = true;
         if ($input->isInteractive()) {
-            $auto = $dialog->askConfirmation($output, $dialog->getQuestion('Confirm automatic update of the Routing', 'yes', '?'), true);
+            $auto = $dialog->ask($output, new ConfirmationQuestion('Confirm automatic update of the Routing: ', 'yes', '?'), true);
         }
 
         $output->write('Importing the REST api routes: ');

--- a/src/Voryx/RESTGeneratorBundle/Command/GeneratorCommand.php
+++ b/src/Voryx/RESTGeneratorBundle/Command/GeneratorCommand.php
@@ -13,7 +13,7 @@ namespace Voryx\RESTGeneratorBundle\Command;
 
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
-use Sensio\Bundle\GeneratorBundle\Command\Helper\DialogHelper;
+use Sensio\Bundle\GeneratorBundle\Command\Helper\QuestionHelper;
 use Voryx\RESTGeneratorBundle\Generator\Generator;
 
 /**
@@ -66,8 +66,8 @@ abstract class GeneratorCommand extends ContainerAwareCommand
     protected function getDialogHelper()
     {
         $dialog = $this->getHelperSet()->get('dialog');
-        if (!$dialog || get_class($dialog) !== 'Sensio\Bundle\GeneratorBundle\Command\Helper\DialogHelper') {
-            $this->getHelperSet()->set($dialog = new DialogHelper());
+        if (!$dialog || get_class($dialog) !== 'Sensio\Bundle\GeneratorBundle\Command\Helper\QuestionHelper') {
+            $this->getHelperSet()->set($dialog = new QuestionHelper());
         }
 
         return $dialog;


### PR DESCRIPTION
Hi, I adapted the generator for symfony 2.5. I just replaced the old doctrine metadata for the new one (just change name) and the dialog helper.

These changes will break any installation with symfony < 2.5. Do't know if you will do a branch for old versions and use master for the most recent compatibility or how do you want to manage this.