### PR TITLE
Correct indentation in the comment for patchAction

### DIFF
--- a/src/Voryx/RESTGeneratorBundle/Resources/skeleton/rest/actions/patch.php.twig
+++ b/src/Voryx/RESTGeneratorBundle/Resources/skeleton/rest/actions/patch.php.twig
@@ -12,7 +12,7 @@
 {% block phpdoc_method_annotations %}
 {% if 'annotation' == format %}{% endif %}
 {% endblock phpdoc_method_annotations %}
-*/
+     */
 {% block method_definition %}
     public function patchAction(Request $request, {{ entity }} $entity)
 {% endblock method_definition %}


### PR DESCRIPTION
The last line in the comment for the patchAction was not indented correctly.