### PR TITLE
Error messages for PUT, PATCH and POST requests with blank bodies

### DIFF
--- a/src/Voryx/RESTGeneratorBundle/Resources/skeleton/rest/actions/post.php.twig
+++ b/src/Voryx/RESTGeneratorBundle/Resources/skeleton/rest/actions/post.php.twig
@@ -31,6 +31,10 @@
             return $entity;
         }
 
+        if (!$form->isSubmitted()) {
+            $form->submit([]);
+        }
+
 {% endblock method_body %}
 {% block method_return %}
         return FOSView::create(array('errors' => $form->getErrors()), Codes::HTTP_INTERNAL_SERVER_ERROR);

--- a/src/Voryx/RESTGeneratorBundle/Resources/skeleton/rest/actions/put.php.twig
+++ b/src/Voryx/RESTGeneratorBundle/Resources/skeleton/rest/actions/put.php.twig
@@ -30,6 +30,10 @@
                 return $entity;
             }
 
+            if (!$form->isSubmitted()) {
+                $form->submit([]);
+            }
+
             return FOSView::create(array('errors' => $form->getErrors()), Codes::HTTP_INTERNAL_SERVER_ERROR);
         } catch (\Exception $e) {
             return FOSView::create($e->getMessage(), Codes::HTTP_INTERNAL_SERVER_ERROR);


### PR DESCRIPTION
-While sending PUT, PATCH and POST requests with blank bodies the response does not shows errors details.
 The response is something like this:

``` json
{
  "errors": {
    "form": {
      "children": {
        "name": {},
        "description": {},
        "category": {}
      }
    },
    "errors": []
  }
}
```

Instead of:

``` json
{
  "errors": {
    "form": {
      "children": {
        "name": {
          "errors": [
            "This value should not be blank."
          ]
        },
        "description": {},
        "category": {
          "errors": [
            "This value should not be blank."
          ]
        }
      }
    },
    "errors": []
  }
}
```

-It seems that when no payload is sent the form is not submitted, in that case we must call $form->submit([]); in order to get errors details
