### PR TITLE
Fixed post and put templates for Symfony3 compatibility

### DIFF
--- a/src/Voryx/RESTGeneratorBundle/Resources/skeleton/rest/actions/post.php.twig
+++ b/src/Voryx/RESTGeneratorBundle/Resources/skeleton/rest/actions/post.php.twig
@@ -19,7 +19,7 @@
     {
 {% block method_body %}
         $entity = new {{ entity }}();
-        $form = $this->createForm({{ entity }}Type::class, $entity, array("method" => $request->getMethod()));
+        $form = $this->createForm(get_class(new {{ entity }}Type()), $entity, array("method" => $request->getMethod()));
         $this->removeExtraFields($request, $form);
         $form->handleRequest($request);
 

--- a/src/Voryx/RESTGeneratorBundle/Resources/skeleton/rest/actions/post.php.twig
+++ b/src/Voryx/RESTGeneratorBundle/Resources/skeleton/rest/actions/post.php.twig
@@ -19,7 +19,7 @@
     {
 {% block method_body %}
         $entity = new {{ entity }}();
-        $form = $this->createForm(new {{ entity }}Type(), $entity, array("method" => $request->getMethod()));
+        $form = $this->createForm({{ entity }}Type::class, $entity, array("method" => $request->getMethod()));
         $this->removeExtraFields($request, $form);
         $form->handleRequest($request);
 

--- a/src/Voryx/RESTGeneratorBundle/Resources/skeleton/rest/actions/put.php.twig
+++ b/src/Voryx/RESTGeneratorBundle/Resources/skeleton/rest/actions/put.php.twig
@@ -21,7 +21,7 @@
         try {
             $em = $this->getDoctrine()->getManager();
             $request->setMethod('PATCH'); //Treat all PUTs as PATCH
-            $form = $this->createForm({{ entity }}Type::class, $entity, array("method" => $request->getMethod()));
+            $form = $this->createForm(get_class(new {{ entity }}Type()), $entity, array("method" => $request->getMethod()));
             $this->removeExtraFields($request, $form);
             $form->handleRequest($request);
             if ($form->isValid()) {

--- a/src/Voryx/RESTGeneratorBundle/Resources/skeleton/rest/actions/put.php.twig
+++ b/src/Voryx/RESTGeneratorBundle/Resources/skeleton/rest/actions/put.php.twig
@@ -21,7 +21,7 @@
         try {
             $em = $this->getDoctrine()->getManager();
             $request->setMethod('PATCH'); //Treat all PUTs as PATCH
-            $form = $this->createForm(new {{ entity }}Type(), $entity, array("method" => $request->getMethod()));
+            $form = $this->createForm({{ entity }}Type::class, $entity, array("method" => $request->getMethod()));
             $this->removeExtraFields($request, $form);
             $form->handleRequest($request);
             if ($form->isValid()) {


### PR DESCRIPTION
According to [symfony 2.8 FormFactory doc](http://api.symfony.com/2.8/Symfony/Component/Form/FormFactory.html) and [symfony 3.0 FormFactory doc](http://api.symfony.com/3.0/Symfony/Component/Form/FormFactory.html), the `FormFactory::createNamed`[1] method interface has changed from version 2.8 to 3.0 from this:
```
createNamed(string|int $name, string|FormTypeInterface $type = 'Symfony\\Component\\Form\\Extension\\Core\\Type\\FormType', mixed $data = null, array $options = array())
```
to this:
```
createNamed(string|int $name, string $type = 'Symfony\\Component\\Form\\Extension\\Core\\Type\\FormType', mixed $data = null, array $options = array()) 
```
I've changed post and put actions template in order to make them compatible with Symfony 3.0 FormFactory API.

[1]: Used at line 24 of `VoryxController.php`.